### PR TITLE
💄 [Design] 플로팅 버튼 위치 조정 

### DIFF
--- a/Indayvidual/Indayvidual/Sources/Common/Components/FloatingBtn/FloatingBtnTemplate.swift
+++ b/Indayvidual/Indayvidual/Sources/Common/Components/FloatingBtn/FloatingBtnTemplate.swift
@@ -40,7 +40,7 @@ struct FloatingButtonModifier: ViewModifier {
 extension View {
     func floatingBtn(
         trailing: CGFloat = 13,
-        bottom: CGFloat = 98,
+        bottom: CGFloat = 17,
         ignoreTabBar: Bool = false,
         action: @escaping () -> Void
     ) -> some View {


### PR DESCRIPTION
## ✨ PR 유형
#25 
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)

## 🛠️ 작업내용
플로팅 버튼 위치 수정

## 📋 추후 진행 상황
투두 리스트 뷰 구현 

## 📌 리뷰 포인트

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * 플로팅 버튼의 기본 하단 여백이 98에서 17로 변경되어 버튼이 화면 아래쪽에 더 가깝게 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->