### PR TITLE
🐛[Fix] 마이 페이지 간 이동

### DIFF
--- a/Indayvidual/Indayvidual/App/IndayvidualApp.swift
+++ b/Indayvidual/Indayvidual/App/IndayvidualApp.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct IndayvidualApp: App {
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            MyPageView()
         }
     }
 }

--- a/Indayvidual/Indayvidual/Sources/Features/MyPage/EditProfileView.swift
+++ b/Indayvidual/Indayvidual/Sources/Features/MyPage/EditProfileView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct EditProfileView: View {
     @Environment(\.dismiss) private var dismiss
+    @State private var goToMyPage = false
 
     @State private var nickname: String = "인데비"
     @State private var email: String = "bbangitnow@gmail.com"
@@ -237,19 +238,25 @@ struct EditProfileView: View {
                             RoundedRectangle(cornerRadius: 12)
                                 .stroke(Color("gray-200"), lineWidth: 1)
                         )
-
-                    Button("저장") {}
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 48)
-                        .background(Color.black)
-                        .foregroundStyle(.white)
-                        .cornerRadius(12)
+                    
+                    Button("저장") {
+                        goToMyPage = true                   }
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 48)
+                            .background(Color.black)
+                            .foregroundStyle(.white)
+                            .cornerRadius(12)
                 }
                 .padding(.horizontal, 20)
                 .padding(.vertical, 12)
                 .background(Color("gray-white"))
+                
+                NavigationLink(destination: MyPageView(), isActive: $goToMyPage) {
+                    EmptyView()
+                }
             }
         }
+        .navigationBarBackButtonHidden(true)
     }
 }
 

--- a/Indayvidual/Indayvidual/Sources/Features/MyPage/MyPageView.swift
+++ b/Indayvidual/Indayvidual/Sources/Features/MyPage/MyPageView.swift
@@ -9,87 +9,98 @@ import SwiftUI
 
 struct MyPageView: View {
     @Environment(\.dismiss) private var dismiss
+    @State private var goToPasswordConfirmView = false
     
     var body: some View {
-        ZStack(alignment: .top) {
-            Color("gray-50").ignoresSafeArea()
-            
-            VStack(spacing: 0) {
-                // 상단 헤더
-                HStack(spacing: 10) {
-                    Button {
-                        dismiss()
-                    } label: {
-                        Image("back-icon")
-                    }
-                    
-                    Text("마이페이지")
-                        .font(.pretendSemiBold18)
-                        .foregroundStyle(Color("gray-900"))
-                    
-                    Spacer()
-                }
-                .padding(.horizontal, 20)
-                .padding(.vertical, 13)
-                .frame(height: 26)
-                .background(Color("gray-white"))
+        NavigationStack {
+            ZStack(alignment: .top) {
+                Color("gray-50").ignoresSafeArea()
                 
-                
-                // 프로필 카드
-                HStack(spacing: 16) {
-                    Image("profile")
-                        .resizable()
-                        .frame(width: 62, height:62 )
-                        .clipShape(RoundedRectangle(cornerRadius: 50))
-                    
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("인데비")
+                VStack(spacing: 0) {
+                    // 상단 헤더
+                    HStack(spacing: 10) {
+                        Button {
+                            dismiss()
+                        } label: {
+                            Image("back-icon")
+                        }
+                        
+                        Text("마이페이지")
                             .font(.pretendSemiBold18)
                             .foregroundStyle(Color("gray-900"))
                         
+                        Spacer()
+                    }
+                    .padding(.horizontal, 20)
+                    .padding(.vertical, 13)
+                    .frame(height: 26)
+                    .background(Color("gray-white"))
+                    
+                    
+                    // 프로필 카드
+                    HStack(spacing: 16) {
+                        Image("profile")
+                            .resizable()
+                            .frame(width: 62, height:62 )
+                            .clipShape(RoundedRectangle(cornerRadius: 50))
                         
-                        HStack(spacing: 2 ) {
-                            Text("내 정보 수정")
-                                .font(.pretendMedium14)
-                                .foregroundStyle(Color("gray-500"))
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("인데비")
+                                .font(.pretendSemiBold18)
+                                .foregroundStyle(Color("gray-900"))
                             
-                            Image("right-arrow")
+                            
+                            HStack(spacing: 2 ) {
+                                Button {
+                                    goToPasswordConfirmView = true
+                                } label: {
+                                    Text("내 정보 수정")
+                                        .font(.pretendMedium14)
+                                        .foregroundStyle(Color("gray-500"))
+                                }
+                                
+                                Image("right-arrow")
+                            }
                         }
-                    }
-                    
-                    Spacer()
-                }
-                .padding(20)
-                .padding(.top, 14)
-                .padding(.bottom, 10)
-                .background(Color("gray-white"))
-                
-                Spacer().frame(height: 10)
-                
-                
-                VStack(spacing: 10){
-                    // 카드 목록
-                    VStack(spacing: 1) {
-                        NavigationRow(icon: "doc.text", title: "위젯 설정") {}
-                            .padding(.bottom, 0)
                         
-                        Divider()
-                            .padding(.horizontal, 20)
-                            .background(Color("gray-100"))
+                        Spacer()
+                    }
+                    .padding(20)
+                    .padding(.top, 14)
+                    .padding(.bottom, 10)
+                    .background(Color("gray-white"))
+                    
+                    Spacer().frame(height: 10)
+                    
+                    
+                    VStack(spacing: 10){
+                        // 카드 목록
+                        VStack(spacing: 1) {
+                            NavigationRow(icon: "doc.text", title: "위젯 설정") {}
+                                .padding(.bottom, 0)
+                            
+                            Divider()
+                                .padding(.horizontal, 20)
+                                .background(Color("gray-100"))
+                            
+                            NavigationRow(icon: "bookmark", title: "구독 관리") {}
+                        }
+                        .background(Color("gray-white"))
+                        .clipShape(RoundedRectangle(cornerRadius: 12))
                         
-                        NavigationRow(icon: "bookmark", title: "구독 관리") {}
+                        VStack(spacing: 1) {
+                            NavigationRow(icon: "bubble.left", title: "인데이비주얼 팀에게 문의하기") {}
+                        }
+                        .background(Color("gray-white"))
+                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                        
+                        Spacer()
                     }
-                    .background(Color("gray-white"))
-                    .clipShape(RoundedRectangle(cornerRadius: 12))
-                    
-                    VStack(spacing: 1) {
-                        NavigationRow(icon: "bubble.left", title: "인데이비주얼 팀에게 문의하기") {}
-                    }
-                    .background(Color("gray-white"))
-                    .clipShape(RoundedRectangle(cornerRadius: 12))
-                    
-                    Spacer()
                 }
+            }
+            .navigationBarBackButtonHidden(true)
+            NavigationLink(destination: PasswordConfirmView(), isActive: $goToPasswordConfirmView) {
+                EmptyView()
             }
         }
     }

--- a/Indayvidual/Indayvidual/Sources/Features/MyPage/PasswordConfirmView.swift
+++ b/Indayvidual/Indayvidual/Sources/Features/MyPage/PasswordConfirmView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct PasswordConfirmView: View {
     @State private var password: String = ""
     @State private var showError: Bool = false
+    @State private var goToNextView = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -68,21 +69,19 @@ struct PasswordConfirmView: View {
                 .frame(height: 30)
 
             // 다음 버튼
-            Button(action: {
-                if password != "correctPassword" { // 예시용 비교
-                    showError = true
-                } else {
-                    showError = false
-                    // 다음으로 진행
+            VStack {
+                NavigationLink(destination: EditProfileView(), isActive: $goToNextView) {
+                    Button(action: {
+                        goToNextView = true // 비밀번호와 관계없이 바로 이동
+                    }) {                Text("다음")
+                            .font(.system(size: 16, weight: .semibold))
+                            .frame(maxWidth: .infinity)
+                            .padding()
+                            .background(Color.black)
+                            .foregroundColor(.white)
+                            .cornerRadius(12)
+                    }
                 }
-            }) {
-                Text("다음")
-                    .font(.system(size: 16, weight: .semibold))
-                    .frame(maxWidth: .infinity)
-                    .padding()
-                    .background(Color.black)
-                    .foregroundColor(.white)
-                    .cornerRadius(12)
             }
 
             Spacer()
@@ -124,6 +123,7 @@ struct PasswordConfirmView: View {
         }
         .padding(.horizontal, 20)
         .navigationBarHidden(true)
+        .navigationBarBackButtonHidden(true)
     }
 }
 


### PR DESCRIPTION
## ✨ PR 유형

어떤 변경 사항이 있나요??
- [x] 테스트 추가, 테스트 리팩토링


## 🛠️ 작업내용
페이지 간 임시 이동

## 📋 추후 진행 상황

## 📌 리뷰 포인트

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 마이페이지에서 "내 정보 수정" 버튼을 누르면 비밀번호 확인 화면으로 이동하는 네비게이션이 추가되었습니다.
  * 비밀번호 확인 후, "다음" 버튼을 누르면 프로필 수정 화면으로 이동합니다.
  * 프로필 수정 후 "저장" 버튼을 누르면 다시 마이페이지로 돌아갑니다.

* **리팩터링**
  * 앱 실행 시 최초 화면이 마이페이지로 변경되었습니다.
  * 각 화면에서 네비게이션 바의 뒤로 가기 버튼이 숨겨졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->