### PR TITLE
🐛 [Fix] task 상태 별 옵션 메뉴 수정 #106

### DIFF
--- a/Indayvidual/Indayvidual/Sources/Common/Enum/TodoActionOption/TodoActionOption.swift
+++ b/Indayvidual/Indayvidual/Sources/Common/Enum/TodoActionOption/TodoActionOption.swift
@@ -6,6 +6,7 @@ enum TodoActionOption: CaseIterable {
     case doTomorrow
     case doAnotherDay
     case doTodoayAgain
+    case doTomorrowAgain
     case delete
     
     var title: String {
@@ -20,6 +21,8 @@ enum TodoActionOption: CaseIterable {
             return "다른 날 또 하기"
         case .doTodoayAgain :
             return "오늘 또 하기"
+        case .doTomorrowAgain :
+            return "내일 또 하기"
         case .delete:
             return "삭제하기"
         }
@@ -36,6 +39,8 @@ enum TodoActionOption: CaseIterable {
         case .doAnotherDay:
             return "redo"
         case .doTodoayAgain:
+            return "doingarrow"
+        case .doTomorrowAgain:
             return "doingarrow"
         case .delete:
             return ""
@@ -55,25 +60,25 @@ enum TodoActionOption: CaseIterable {
             // 완료된 task의 경우
             if taskDay < today {
                 // 과거 완료된 task
-                options = [.changeDate, .doToday, .doTodoayAgain, .doAnotherDay]
+                options = [.doTodoayAgain, .doAnotherDay]
             } else if taskDay == today {
                 // 오늘 완료된 task
-                options = [.changeDate, .doTomorrow, .doTodoayAgain, .doAnotherDay]
+                options = [.doTomorrowAgain, .doAnotherDay]
             } else {
                 // 미래 완료된 task (일반적이지 않은 케이스)
-                options = [.changeDate]
+                options = [.doTodoayAgain, .doAnotherDay]
             }
         } else {
             // 미완료된 task의 경우
             if taskDay < today {
                 // 과거 미완료된 task
-                options = [.changeDate, .doToday, .doTomorrow, .doAnotherDay]
+                options = [.changeDate, .doToday, .doTomorrow]
             } else if taskDay == today {
                 // 오늘 미완료된 task
                 options = [.changeDate, .doTomorrow]
             } else {
                 // 미래 미완료된 task
-                options = [.changeDate, .doToday, .doTodoayAgain, .doAnotherDay]
+                options = [.changeDate, .doToday, .doTomorrow]
             }
         }
         return options

--- a/Indayvidual/Indayvidual/Sources/Features/TodoList/ViewModel/TodoActionViewModel.swift
+++ b/Indayvidual/Indayvidual/Sources/Features/TodoList/ViewModel/TodoActionViewModel.swift
@@ -21,6 +21,8 @@ class TodoActionViewModel: ObservableObject {
     func handleAction(_ option: TodoActionOption, for task: TodoTask) {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd"
+        let tomorrow = Calendar.current.date(byAdding: .day, value: 1, to: Date()) ?? Date()
+        let tomorrowString = dateFormatter.string(from: tomorrow)
         
         switch option {
         case .changeDate:
@@ -36,13 +38,7 @@ class TodoActionViewModel: ObservableObject {
             }
             
         case .doTomorrow:
-            let tomorrow = Calendar.current.date(byAdding: .day, value: 1, to: Date()) ?? Date()
-            let tomorrowString = dateFormatter.string(from: tomorrow)
-            if task.isCompleted {
-                todoManager.duplicateTask(task, to: tomorrowString) // 완료된 task는 복사
-            } else {
-                todoManager.moveTask(task, to: tomorrowString) // 미완료된 task는 이동
-            }
+            todoManager.moveTask(task, to: tomorrowString) // 미완료된 task는 이동
             
         case .doAnotherDay:
             selectedActionDate = Date()
@@ -51,7 +47,10 @@ class TodoActionViewModel: ObservableObject {
         case .doTodoayAgain:
             let today = dateFormatter.string(from: Date())
             todoManager.duplicateTask(task, to: today)
-
+            
+        case .doTomorrowAgain:
+            todoManager.duplicateTask(task, to: tomorrowString) // 완료된 task는 복사
+            
         case .delete:
             todoManager.deleteTask(task)
         }


### PR DESCRIPTION
#106 요청사항에 맞게 task 상태 별 옵션 메뉴 수정

## ✨ PR 유형

어떤 변경 사항이 있나요??

- [x] 버그 수정


## 🛠️ 작업내용
task 상태별 옵션 시트 내용 수정

<오늘 날짜>
미완료 - 날짜 바꾸기, 내일 하기
완료 - 내일 또 하기, 다른 날 또 하기

<과거 & 미래 날짜>
미완료 - 날짜 바꾸기, 오늘 하기, 내일 하기
완료 - 오늘 또 하기, 다른 날 또 하기


## 📋 추후 진행 상황
디자인 수정


## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * "내일 또 하기" 작업 옵션이 추가되었습니다. 이제 완료된 작업에 대해 "내일 또 하기"를 선택할 수 있습니다.

* **기능 개선**
  * 작업의 완료 상태와 날짜에 따라 표시되는 작업 옵션이 보다 직관적으로 조정되었습니다.
  * 내일 관련 작업 옵션의 동작이 간소화되어, "내일로 이동"과 "내일 또 하기"가 명확히 구분됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->