### PR TITLE
💄 [Design] 컬러시트 스타일 통일

### DIFF
--- a/Indayvidual/Indayvidual/Sources/Common/Components/ActionSheet/CustomActionSheet.swift
+++ b/Indayvidual/Indayvidual/Sources/Common/Components/ActionSheet/CustomActionSheet.swift
@@ -8,7 +8,8 @@ struct CustomActionSheet<Content: View>: View {
     let primaryAction: () -> Void
     let secondaryAction: (() -> Void)?
     let content: Content
-    let showDivider: Bool
+    let showTopDivider: Bool
+    let showBottomDivider: Bool
     let headerRightButton: (() -> AnyView)?
     let headerLeftButton: (() -> AnyView)? 
 
@@ -29,7 +30,8 @@ struct CustomActionSheet<Content: View>: View {
         secondaryButtonTitle: String? = "취소",
         primaryAction: @escaping () -> Void = { print("기본 액션") },
         secondaryAction: (() -> Void)? = { print("취소 액션") },
-        showDivider: Bool = true,
+        showTopDivider: Bool = true,
+        showBottomDivider: Bool = false,
         primaryButtonColor: Color = .gray900,
         primaryButtonTextColor: Color = .grayWhite,
         secondaryButtonColor: Color = .grayWhite,
@@ -48,7 +50,8 @@ struct CustomActionSheet<Content: View>: View {
         self.secondaryButtonTitle = secondaryButtonTitle
         self.primaryAction = primaryAction
         self.secondaryAction = secondaryAction
-        self.showDivider = showDivider
+        self.showTopDivider = showTopDivider
+        self.showBottomDivider = showBottomDivider
         self.primaryButtonColor = primaryButtonColor
         self.primaryButtonTextColor = primaryButtonTextColor
         self.secondaryButtonColor = secondaryButtonColor
@@ -87,7 +90,7 @@ struct CustomActionSheet<Content: View>: View {
             .padding(.top, 30.58)
             .padding(.bottom, 17.69)
             .padding(.horizontal, 15.4)
-            if showDivider {
+            if showBottomDivider {
                 Divider()
                     .padding(.horizontal, 15.4)
                     .padding(.bottom, 20)
@@ -95,6 +98,13 @@ struct CustomActionSheet<Content: View>: View {
 
             content.padding(.horizontal, 15)
             Spacer()
+            
+            if showTopDivider {
+                Divider()
+                    .padding(.horizontal, 15.4)
+                    .padding(.bottom, 20)
+            }
+            
             HStack(spacing: 12) {
                 if let secondaryButtonTitle = secondaryButtonTitle,
                    let secondaryAction = secondaryAction {

--- a/Indayvidual/Indayvidual/Sources/Common/Components/ColorTable/ColorGridView.swift
+++ b/Indayvidual/Indayvidual/Sources/Common/Components/ColorTable/ColorGridView.swift
@@ -13,28 +13,31 @@ struct ColorGridView: View {
     let columns = Array(repeating: GridItem(.flexible(), spacing: 31), count: 5)
 
     var body: some View {
-        LazyVGrid(columns: columns, spacing: 24) {
-            ForEach(viewModel.colors) { colorItem in
-                Color(colorItem.name)
-                    .frame(width: 39.39, height: 39.39)
-                    .clipShape(Circle())
-                    .overlay(
-                            Group {
-                                if colorItem.isSelected {
-                                    Image("check-icon")
-                                        .resizable()
-                                        .scaledToFit()
-                                        .frame(width: 20, height: 13)
+        VStack{
+            LazyVGrid(columns: columns, spacing: 30) {
+                ForEach(viewModel.colors) { colorItem in
+                    Color(colorItem.name)
+                        .frame(width: 42.39, height: 42.39)
+                        .clipShape(Circle())
+                        .overlay(
+                                Group {
+                                    if colorItem.isSelected {
+                                        Image("check-icon")
+                                            .resizable()
+                                            .scaledToFit()
+                                            .frame(width: 20, height: 13)
+                                    }
                                 }
-                            }
-                        )
-                    .onTapGesture {
-                        viewModel.colorSelection(for: colorItem.id)
-                    }
+                            )
+                        .onTapGesture {
+                            viewModel.colorSelection(for: colorItem.id)
+                        }
+                }
             }
         }
-        .padding(.vertical, 30)
-        .frame(width: 323, height: 488)
+        .padding(.horizontal, 20)
+        .padding(.vertical, 20)
+        
     }
    
 }

--- a/Indayvidual/Indayvidual/Sources/Features/Custom/Habit/Views/HabitFormView.swift
+++ b/Indayvidual/Indayvidual/Sources/Features/Custom/Habit/Views/HabitFormView.swift
@@ -25,6 +25,7 @@ struct HabitFormView: View {
             .sheet(isPresented: $showColorTable) {
                 sheetView
                     .presentationDragIndicator(.visible)
+                    .presentationDetents([.large])
             }.menuIndicator(.visible)
         }
         .navigationBarBackButtonHidden(true)
@@ -134,9 +135,10 @@ struct HabitFormView: View {
                 if let firstColor = colorViewModel.colors.first {
                     colorViewModel.colorSelection(for: firstColor.id)
                 }
-            }
+            },
+            showBottomDivider: true
         ) {
-            VStack(alignment: .leading, spacing: 0) {
+            VStack(spacing: 0) {
                 ColorGridView(viewModel: colorViewModel)
             }
         }

--- a/Indayvidual/Indayvidual/Sources/Features/Home/Views/ColorPickerSheetView.swift
+++ b/Indayvidual/Indayvidual/Sources/Features/Home/Views/ColorPickerSheetView.swift
@@ -28,6 +28,7 @@ struct ColorPickerSheetView: View {
             secondaryAction: {
                 colorVm.resetToDefault()
             },
+            showBottomDivider: true,
             primaryButtonColor: .gray900,
             primaryButtonTextColor: .white,
             secondaryButtonColor: .white,
@@ -35,7 +36,7 @@ struct ColorPickerSheetView: View {
             secondaryButtonBorderColor: .gray200,
             buttonHeight: 55
         ) {
-            VStack(alignment: .center, spacing: 0) {
+            VStack(spacing: 0) {
                 ColorGridView(viewModel: colorVm)
             }
         }

--- a/Indayvidual/Indayvidual/Sources/Features/TimeTable/Views/SchoolSearchPopup.swift
+++ b/Indayvidual/Indayvidual/Sources/Features/TimeTable/Views/SchoolSearchPopup.swift
@@ -44,7 +44,7 @@ struct SchoolSearchPopup: View {
                     secondaryAction: {
                         isPresented = false
                     },
-                    showDivider: false,
+                    showTopDivider: false,
                     primaryButtonColor: searchText == "" ? .gray100 : .gray900
                 ) {
                     VStack(spacing: 0) {

--- a/Indayvidual/Indayvidual/Sources/Features/TodoList/View/TodoCategorySelectView.swift
+++ b/Indayvidual/Indayvidual/Sources/Features/TodoList/View/TodoCategorySelectView.swift
@@ -38,12 +38,15 @@ struct TodoCategorySelectView: View {
         }
         .sheet(isPresented: $showColorPicker) {
             colorPickerSheet
+                .presentationDragIndicator(.visible)
+                .presentationDetents([.large])
         }
+        
         .onAppear {
             todoViewModel.fetchCategories() // 뷰 등장 시 카테고리 목록 조회
         }
     }
-
+    
     // MARK: - Edit Mode View
     private var editModeView: some View {
         VStack(spacing: 0) {
@@ -58,7 +61,7 @@ struct TodoCategorySelectView: View {
                 SelectColorField(selectedColor: $selectedColor, showColorPicker: $showColorPicker)
                 statusView
                 Spacer().frame(height: 20)
-
+                
                 Button {
                     handleCategorySubmission()
                 } label: {
@@ -84,7 +87,7 @@ struct TodoCategorySelectView: View {
         .presentationDetents([.height(300), .medium])
         .presentationDragIndicator(.hidden)
     }
-
+    
     // MARK: - Normal Mode View
     private var normalModeView: some View {
         VStack(spacing: 14) {
@@ -122,7 +125,7 @@ struct TodoCategorySelectView: View {
             }
         }
     }
-
+    
     // MARK: - Status View
     private var statusView: some View {
         VStack(spacing: 8) {
@@ -135,7 +138,7 @@ struct TodoCategorySelectView: View {
             }
         }
     }
-
+    
     // MARK: - Color Picker Sheet
     private var colorPickerSheet: some View {
         CustomActionSheet(
@@ -154,30 +157,31 @@ struct TodoCategorySelectView: View {
                 colorViewModel.resetToDefault()
                 selectedColor = .purple05
                 showColorPicker = false
-            }
+            },
+            showBottomDivider: true
         ) {
-            VStack(alignment: .leading) {
+            VStack(spacing: 0) {
                 ColorGridView(viewModel: colorViewModel)
             }
         }
     }
-
+    
     // MARK: - 버튼 기능과 색상 변화
     private var isButtonDisabled: Bool { categoryName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
-
+    
     private var buttonBackgroundColor: Color {
         isButtonDisabled ? Color.gray300 : Color.gray900
     }
-
+    
     // MARK: - Methods
     private func handleCategorySubmission() {
         let trimmedName = categoryName.trimmingCharacters(in: .whitespacesAndNewlines)
-
+        
         if isEditMode {
             guard let targetCategory = categoryToUpdate else {
-               return
-           }
+                return
+            }
             todoViewModel.updateCategory(
                 targetCategory, newName: trimmedName,
                 newColor: selectedColor
@@ -208,7 +212,7 @@ struct TodoCategorySelectView: View {
 
 struct CustomPlaceholderTextField: View {
     @Binding var text: String
-
+    
     var body: some View {
         ZStack(alignment: .leading) {
             RoundedRectangle(cornerRadius: 8)
@@ -238,7 +242,7 @@ struct CustomPlaceholderTextField: View {
 struct SelectColorField: View {
     @Binding var selectedColor: Color
     @Binding var showColorPicker: Bool
-
+    
     var body: some View {
         Button {
             showColorPicker = true


### PR DESCRIPTION
## ✨ PR 유형

어떤 변경 사항이 있나요??

- [x] 사용자 UI 디자인 변경 및 추가

## 🛠️ 작업내용
- 홈, 투두, 커스텀 컬러 시트 스타일 통일 (높이, 액션 시트 하단 Divider 추가)
- 컬러 그리드 시트 frame -> padding으로 여백 수정

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 새로운 기능
  - 카테고리 선택: 편집 모드에 “완료” 버튼 추가. 추가/수정 성공 시 화면 자동 닫힘 및 콜백 호출, 실패 시 오류 메시지 표시.
  - 컬러 선택 시트: 큰 높이(detent)와 드래그 인디케이터 지원. 색 선택/초기화 액션이 시트를 닫고 선택을 반영.

- 개선
  - 액션 시트 구분선 제어를 상·하단으로 분리해 화면 일관성 향상.
  - 색상 격자 간격·셀 크기 조정 및 패딩 기반 레이아웃으로 가독성 향상.
  - 카테고리 목록을 화면 진입 시 자동 로드.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->