### PR TITLE
💄 [Design] CustomCalendar 월 캘린더 높이 유동적으로 변경

### DIFF
--- a/Indayvidual/Indayvidual/Sources/Common/Components/Calendar/CustomCalendarView.swift
+++ b/Indayvidual/Indayvidual/Sources/Common/Components/Calendar/CustomCalendarView.swift
@@ -74,8 +74,8 @@ struct CustomCalendarView: View {
             
         )
         .task {
-                   calendarViewModel.calendarMode = initialMode
-               }
+            calendarViewModel.calendarMode = initialMode
+        }
     }
     
     @ViewBuilder
@@ -130,7 +130,7 @@ struct CalendarHeaderView: View {
             }
         }
         .padding(.horizontal, 10)
-        .padding(.bottom, 20)
+        .padding(.bottom, 15.97)
     }
     
     private var toggleButton: some View {
@@ -177,7 +177,7 @@ struct WeekdayHeaderView: View {
                     .multilineTextAlignment(.center)
             }
         }
-        .padding(.bottom, 30)
+        .padding(.bottom, 17.73)
     }
 }
 
@@ -188,9 +188,6 @@ struct MonthlyCalendarView: View {
     var onDateSelected: ((Date) -> Void)?
     
     private let columns = Array(repeating: GridItem(.flexible(), spacing: 0), count: 7)
-    
-    private let rowCount: CGFloat = 6
-    private let itemHeight: CGFloat = 30
     
     var body: some View {
         
@@ -212,15 +209,10 @@ struct MonthlyCalendarView: View {
                     )
                 } else {
                     // isCurrentMonth가 false이면(이전/다음 달) 투명한 빈 공간
-                    Color.clear.frame(height: 28)
+                    Color.clear
                 }
             }
         }
-        .frame(height: calculateMaxHeight())
-    }
-    
-    private func calculateMaxHeight() -> CGFloat {
-        (itemHeight * rowCount) + (rowCount - 1)
     }
 }
 

--- a/Indayvidual/Indayvidual/Sources/Common/Components/Calendar/CustomCalendarViewModel.swift
+++ b/Indayvidual/Indayvidual/Sources/Common/Components/Calendar/CustomCalendarViewModel.swift
@@ -167,29 +167,34 @@ final class CustomCalendarViewModel: ObservableObject {
         }
         
         // 3. 현재 달 날짜 추가
-        for day in 1...daysInMonth {
-            if let date = calendar.date(bySetting: .day, value: day, of: firstDay) {
-                days.append(DateValue(day: day, date: date, isCurrentMonth: true))
-            }
-        }
-        
-        // 4. 다음 달 날짜 추가 (뒤쪽 공백 채우기)
-        let totalDays = 42 // 6주 * 7일 = 42개의 셀을 기준으로 고정
-        let remainingDays = totalDays - days.count
-        
-        if remainingDays > 0 {
-            guard let firstDayOfNextMonth = calendar.date(byAdding: .month, value: 1, to: firstDay) else {
-                return []
-            }
-            
-            for day in 1...remainingDays {
-                if let date = calendar.date(byAdding: .day, value: day - 1, to: firstDayOfNextMonth) {
-                    days.append(DateValue(day: day, date: date, isCurrentMonth: false))
+            var lastDayOfMonth: Date?
+            for day in 1...daysInMonth {
+                if let date = calendar.date(bySetting: .day, value: day, of: firstDay) {
+                    days.append(DateValue(day: day, date: date, isCurrentMonth: true))
+                    lastDayOfMonth = date
                 }
             }
-        }
         
-        return days
+        // 4. 마지막 주 토요일까지 채우기 (필요한 만큼만)
+            if let lastDay = lastDayOfMonth {
+                let lastWeekday = calendar.component(.weekday, from: lastDay) // 1~7
+                let trailingDays = 7 - ((lastWeekday - calendar.firstWeekday + 7) % 7) - 1
+                
+                if trailingDays > 0 {
+                    guard let firstDayOfNextMonth = calendar.date(byAdding: .day, value: 1, to: lastDay) else {
+                        return days
+                    }
+                    
+                    for i in 0..<trailingDays {
+                        if let date = calendar.date(byAdding: .day, value: i, to: firstDayOfNextMonth) {
+                            let day = calendar.component(.day, from: date)
+                            days.append(DateValue(day: day, date: date, isCurrentMonth: false))
+                        }
+                    }
+                }
+            }
+            
+            return days
     }
     
     // 주 기준 날짜 배열 생성


### PR DESCRIPTION
## ✨ PR 유형

어떤 변경 사항이 있나요??

- [x] 사용자 UI 디자인 변경 및 추가

## 🛠️ 작업내용
- CustomCalendar 월 캘린더 높이 유동적으로 변경

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 스타일
  * 캘린더 헤더와 요일 헤더의 하단 여백을 줄여 화면 공간 활용을 개선했습니다.
* 리팩터링
  * 월간 캘린더의 고정 6행(42칸) 레이아웃을 제거하고, 마지막 주까지만 표시하는 가변 높이로 전환했습니다.
  * 월 외 날짜 셀을 고정 높이 없이 투명 처리하여 배치 안정성을 높였습니다.
* 버그 수정
  * 마지막 주 채움 로직을 월의 실제 마지막 요일 기준으로 계산해 불필요한 빈 칸/빈 주가 나타나지 않도록 했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->