### PR TITLE
💄 [Design] HomeView 일정 리스트 여백 조정

### DIFF
--- a/Indayvidual/Indayvidual/Sources/Features/Home/Views/Components/ScheduleListView.swift
+++ b/Indayvidual/Indayvidual/Sources/Features/Home/Views/Components/ScheduleListView.swift
@@ -58,9 +58,8 @@ struct ScheduleListView: View {
                 .cornerRadius(15)
                 .listRowSeparator(.hidden)
                 .listRowBackground(Color.clear)
-                .listRowInsets(EdgeInsets()) // 리스트 기본 Insets 제거
-                .padding(.bottom, 14)
-                .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                .listRowInsets(EdgeInsets(top: 7, leading: 0, bottom: 7, trailing: 0))
+                .swipeActions(edge: .trailing) {
                     Button(role: .destructive) {
                         homeVm.deleteSchedule(schedule, calendarViewModel: calendarVm)
                     } label: {

--- a/Indayvidual/Indayvidual/Sources/Features/Home/Views/HomeView.swift
+++ b/Indayvidual/Indayvidual/Sources/Features/Home/Views/HomeView.swift
@@ -54,15 +54,11 @@ struct HomeView: View {
                             on: schedule.startTime ?? calendarVm.selectDate,
                             calendarViewModel: calendarVm
                         )
-                    }
-                    )
-                    
+                    })
                     .environmentObject(homeVm)
                 }
             }
             .padding(.horizontal, 28)
-            
-            
             
             Spacer()
         }
@@ -70,7 +66,6 @@ struct HomeView: View {
             homeVm.setup(alertService: alertService)
             
             // 기존 필터 업데이트
-            homeVm.updateFilteredSchedules(for: calendarVm.selectDate)
             homeVm.fetchSchedules(for: calendarVm.selectDate)
             
             // 서버에서 해당 월의 마커 정보 불러오기


### PR DESCRIPTION
## ✨ PR 유형

어떤 변경 사항이 있나요??

- [x] 사용자 UI 디자인 변경 및 추가
- [x] 버그 수정

## 🛠️ 작업내용
- 일정 리스트와 스와이프 액션바 높이가 안맞는데, 완벽히 일치 시킬 수 없어서 내부 여백을 조정해서 균형 맞춤
- HomeView updateFilteredSchedules 중복 호출 제거

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 스타일
  - 일정 목록 항목의 세로 여백을 늘려 가독성을 개선했습니다.
- 버그 수정
  - 일정 항목의 스와이프 동작을 조정해 전체 스와이프가 가능하도록 했습니다.
- 리팩터링
  - 홈 화면 최초 진입 시 동작을 단순화하여 선택된 날짜의 일정만 불러오도록 정리했습니다.
  - 뷰 구성의 불필요한 포맷을 정돈해 표현을 간결하게 했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->