### PR TITLE
🐛 [Fix] Todo tool bar 변경

### DIFF
--- a/Indayvidual/Indayvidual/Sources/Features/TodoList/View/TodoCategorySelectView.swift
+++ b/Indayvidual/Indayvidual/Sources/Features/TodoList/View/TodoCategorySelectView.swift
@@ -101,7 +101,7 @@ struct TodoCategorySelectView: View {
         .background(Color.gray50)
         .navigationBarBackButtonHidden(true)
         .toolbar {
-            ToolbarItem(placement: .navigationBarLeading) {
+            ToolbarItem(placement: .topBarLeading) {
                 Button {
                     dismiss()
                 } label: {
@@ -115,7 +115,7 @@ struct TodoCategorySelectView: View {
                     .font(.pretendSemiBold18)
                     .foregroundStyle(.black)
             }
-            ToolbarItem(placement: .navigationBarTrailing) {
+            ToolbarItem(placement: .topBarTrailing) {
                 Button("등록") {
                     handleCategorySubmission()
                 }

--- a/Indayvidual/Indayvidual/Sources/Features/TodoList/View/TodoListView.swift
+++ b/Indayvidual/Indayvidual/Sources/Features/TodoList/View/TodoListView.swift
@@ -15,9 +15,6 @@ struct TodoListView: View {
     var body: some View {
         NavigationStack(path: $path) {
             VStack(spacing: 0) {
-                Topbar(customAction: {
-                    path.append(Route1.editCategory)
-                })
                 ScrollView {
                     VStack(spacing: 0) {
                         CalendarWithScheduleListView(
@@ -78,6 +75,17 @@ struct TodoListView: View {
                         }
                         
                         Spacer()
+                    }.toolbar {
+                        ToolbarItem(placement: .topBarLeading) {
+                            Image(.indayvidual)
+                        }
+                        ToolbarItem(placement: .topBarTrailing) {
+                            Button {
+                                path.append(Route1.editCategory)
+                            } label: {
+                                Image("gear")
+                            }
+                        }
                     }
                 }
                 .scrollBounceBehavior(.basedOnSize)


### PR DESCRIPTION
#163 
## ✨ PR 유형

- [x] 버그 수정
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)

## 🛠️ 작업내용
공통 컴포넌트 topbar -> toolbar로 변경

## 📋 추후 진행 상황
todolist뷰와 home뷰의 일정이 없을 떄 뜨는 뷰 사이즈 통일

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Todo 카테고리 선택 화면의 툴바를 상단 바 리딩/트레일링으로 재배치하여 일관된 상단 배치 제공. 기존 동작(닫기/완료, 제목)에는 변화 없음.
  * 할 일 목록 화면에서 커스텀 Topbar를 제거하고 콘텐츠 영역에 툴바를 도입. 좌측에 앱 아이콘, 우측에 톱니바퀴 버튼을 배치해 카테고리 편집으로 이동 가능. 내비게이션 흐름과 달력/목록 기능은 기존과 동일.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->